### PR TITLE
Redirect web server root path to attendance instructions

### DIFF
--- a/inventory/group_vars/matrix_servers.yml
+++ b/inventory/group_vars/matrix_servers.yml
@@ -10,8 +10,10 @@
 #
 # Example value: example.com
 matrix_domain: "{{ now(fmt='%Y') }}.seagl.org"
+matrix_static_files_file_index_html_enabled: false
 matrix_static_files_file_matrix_support_enabled: true
 matrix_static_files_container_labels_base_domain_enabled: true
+matrix_static_files_container_labels_base_domain_root_path_redirection_url: https://seagl.org/attend
 
 matrix_server_fqn_matrix: "{{ now(fmt='%Y') }}-ephemeral.host.seagl.org"
 


### PR DESCRIPTION
Current behavior:

```console
$ curl 'https://2024.seagl.org/'
<!doctype html>
<meta charset="utf-8" />
<html>
  <body>
    Hello from 2024.seagl.org!
  </body>
</html>
```