### PR TITLE
Raise join/invite rate limits for bursty usage patterns

### DIFF
--- a/inventory/group_vars/matrix_servers.yml
+++ b/inventory/group_vars/matrix_servers.yml
@@ -18,6 +18,15 @@ matrix_server_fqn_matrix: "{{ now(fmt='%Y') }}-ephemeral.host.seagl.org"
 # Enable or disable this when the time is right
 matrix_synapse_enable_registration: true
 
+# Raise rate limits for bursty usage patterns
+matrix_synapse_rc_invites:
+  per_room: {per_second: 1, burst_count: 100}
+  per_user: {per_second: 1, burst_count: 100}
+  per_issuer: {per_second: 1, burst_count: 100}
+matrix_synapse_rc_joins:
+  local: {per_second: 1, burst_count: 100}
+  remote: {per_second: 1, burst_count: 100}
+
 matrix_client_element_enabled: false
 devture_playbook_state_preserver_vars_preservation_enabled: false
 


### PR DESCRIPTION
These numbers are just a guess and what I’ve been using on the staging instance.