### PR TITLE
Audit registrations

### DIFF
--- a/inventory/group_vars/matrix_servers.yml
+++ b/inventory/group_vars/matrix_servers.yml
@@ -86,3 +86,9 @@ postgres_connection_password: !vault |
 # Example: `matrix_coturn_turn_external_ip_addresses: ['1.2.3.4', '4.5.6.7']`
 #
 # matrix_coturn_turn_external_ip_address: ''
+
+# Audit user registrations
+matrix_synapse_ext_audit_registrations_enabled: true
+matrix_synapse_ext_audit_registrations_config:
+  room_alias: "#triage:seagl.org"
+  user_id: "@notifications:{{ now(fmt='%Y') }}.seagl.org"

--- a/inventory/group_vars/matrix_servers.yml
+++ b/inventory/group_vars/matrix_servers.yml
@@ -90,5 +90,5 @@ postgres_connection_password: !vault |
 # Audit user registrations
 matrix_synapse_ext_audit_registrations_enabled: true
 matrix_synapse_ext_audit_registrations_config:
-  room_alias: "#triage:seagl.org"
+  room_alias: "#audit:{{ now(fmt='%Y') }}.seagl.org"
   user_id: "@notifications:{{ now(fmt='%Y') }}.seagl.org"

--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1342,6 +1342,9 @@ matrix_synapse_ext_synapse_auto_accept_invite_worker_to_run_on: null
 # If it is, the Synapse media repo and media-repo workers will be disabled automatically.
 matrix_synapse_ext_media_repo_enabled: false
 
+# Auditing of user registrations
+matrix_synapse_ext_audit_registrations_enabled: false
+
 matrix_s3_media_store_enabled: false
 matrix_s3_media_store_custom_endpoint_enabled: false
 matrix_s3_goofys_docker_image: "{{ matrix_s3_goofys_docker_image_name_prefix }}ewoutp/goofys:latest"

--- a/roles/custom/matrix-synapse/tasks/ext/audit-registrations/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/audit-registrations/setup_install.yml
@@ -1,0 +1,69 @@
+---
+
+- name: Install audit registrations module
+  ansible.builtin.copy:
+    dest: "{{ matrix_synapse_ext_path }}/audit_registrations.py"
+    owner: "{{ matrix_synapse_uid }}"
+    group: "{{ matrix_synapse_gid }}"
+    mode: 0440
+    content: |
+      import logging
+      from synapse.module_api.errors import SynapseError
+
+      logger = logging.getLogger(__name__)
+
+
+      class AuditRegistrations:
+          def __init__(self, config, api):
+              self._api = api
+              self._room_alias = config["room_alias"]
+              self._user_id = config["user_id"]
+
+              self._api.register_account_validity_callbacks(
+                  on_user_registration=self.on_user_registration
+              )
+
+          async def on_user_registration(self, user_id):
+              try:
+                  (room_id, _) = await self._api.lookup_room_alias(self._room_alias)
+
+                  await self._api.create_and_send_event_into_room(
+                      {
+                          "sender": self._user_id,
+                          "room_id": room_id,
+                          "type": "m.room.message",
+                          "content": {
+                              "msgtype": "m.notice",
+                              "body": f"User registration: {user_id}",
+                          },
+                      }
+                  )
+              except SynapseError as e:
+                  logger.error("Failed to report user registration %s: %s", user_id, e)
+
+- ansible.builtin.set_fact:
+    matrix_synapse_modules: |
+      {{
+        matrix_synapse_modules | default([])
+        +
+        [
+          {
+            "module": "audit_registrations.AuditRegistrations",
+            "config": matrix_synapse_ext_audit_registrations_config
+          }
+        ]
+      }}
+
+    matrix_synapse_container_extra_arguments: >
+      {{
+        matrix_synapse_container_extra_arguments | default([])
+        +
+        ["--mount type=bind,src={{ matrix_synapse_ext_path }}/audit_registrations.py,dst={{ matrix_synapse_in_container_python_packages_path }}/audit_registrations.py,ro"]
+      }}
+
+    matrix_synapse_additional_loggers_auto: >
+      {{
+        matrix_synapse_additional_loggers_auto
+        +
+        [{'name': 'audit_registrations', 'level': 'INFO'}]
+      }}

--- a/roles/custom/matrix-synapse/tasks/ext/audit-registrations/setup_uninstall.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/audit-registrations/setup_uninstall.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Uninstall audit registrations module
+  ansible.builtin.file:
+    path: "{{ matrix_synapse_ext_path }}/audit_registrations.py"
+    state: absent

--- a/roles/custom/matrix-synapse/tasks/ext/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/setup_install.yml
@@ -82,3 +82,13 @@
   block:
     - when: matrix_synapse_ext_synapse_auto_accept_invite_enabled | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/ext/synapse-auto-accept-invite/setup_install.yml"
+
+# audit-registrations
+- tags:
+    - setup-all
+    - setup-synapse
+    - install-all
+    - install-synapse
+  block:
+    - when: matrix_synapse_ext_audit_registrations_enabled | bool
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/ext/audit-registrations/setup_install.yml"

--- a/roles/custom/matrix-synapse/tasks/ext/setup_uninstall.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/setup_uninstall.yml
@@ -50,3 +50,11 @@
   block:
     - when: not matrix_synapse_ext_synapse_s3_storage_provider_enabled | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/ext/s3-storage-provider/setup_uninstall.yml"
+
+# audit-registrations
+- tags:
+    - setup-all
+    - setup-synapse
+  block:
+    - when: not matrix_synapse_ext_audit_registrations_enabled | bool
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/ext/audit-registrations/setup_uninstall.yml"


### PR DESCRIPTION
Not really sure if we’d want this, but exploring the idea. Now that we’re administering Synapse we have the ability to add custom [Synapse modules](https://element-hq.github.io/synapse/latest/modules/).

In past years we’ve been blind to actual user registrations and relied upon observing room membership as a proxy, but that risks missing problems like conference attendees failing to join the space or deliberate abuse. As a simple mitigation, this hooks into [`on_user_registration`](https://element-hq.github.io/synapse/latest/modules/account_validity_callbacks.html#on_user_registration) and logs each new user in a moderation room for human review.