### PR TITLE
Make Matrix FQDN pretty

### DIFF
--- a/inventory/group_vars/matrix_servers.yml
+++ b/inventory/group_vars/matrix_servers.yml
@@ -15,7 +15,7 @@ matrix_static_files_file_matrix_support_enabled: true
 matrix_static_files_container_labels_base_domain_enabled: true
 matrix_static_files_container_labels_base_domain_root_path_redirection_url: https://seagl.org/attend
 
-matrix_server_fqn_matrix: "{{ now(fmt='%Y') }}-ephemeral.host.seagl.org"
+matrix_server_fqn_matrix: "matrix.{{ now(fmt='%Y') }}.seagl.org"
 
 # Enable or disable this when the time is right
 matrix_synapse_enable_registration: true


### PR DESCRIPTION
Builds on SeaGL/seagl-terraform#87

I don't know what the potential consequences of changing this after the fact would be... but it seems like it should be fine, because the actual user ID homeserver component hasn't changed?